### PR TITLE
two modifications to increase usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It has a fixed number of columns and hence easier to edit in Excel or other tabu
 Level,IsOpen,Title,Page
 ```
 
-The tab-delimited equivalent of the above toc would be:
+The tab-delimited equivalent of the above toc would be (ignore the empty "header" line):
 
 |||||
 |-|-|-|-|
@@ -62,19 +62,22 @@ The tab-delimited equivalent of the above toc would be:
 Where:
 - `Level` is a non-empty zero-based integer indicating the depth of the current item in the bookmarks
 - `IsOpen`, if not blank, indicates whether this entry is opened by default, and can be any **single character**
-- The file can't contain empty lines, headers, comments, etc.
+- The file can't contain headers, comments, and empty lines.
 
 Technically, each line of this toc format should match the regular expression `^([0-9]+)\t(.?)\t(.+?)\t(-?[0-9]+)$`.
 
 # Usage
 ```
-$ pdfmark --in <input> --toc <toc-file> --out <output> [--offset <offset>] [--tsv]
+$ pdfmark --in <input> --toc <toc-file> --out <output> [--offset <offset>] [--tsv] [--page <page>] [--fit page|width] [--print-pdfmarks]
 ```
-Where `<input>`, and `<output>` are input PDF and output PDF, `<toc-file>`
-is the toc file as described above, and the option `<offset>` is optional, it
-stands for the offset that should be added to the page numbers in toc file in order
-to get the real page number in the PDF file.
-Use `--tsv` to indicate that the toc file format is tab-delimited.
+Where:
+- `<input>`, and `<output>` are input PDF and output PDF
+- `<toc-file>` is the toc file as described above
+- `<offset>` (optional) stands for the offset that should be added to the page numbers in toc file in order to get the real page number in the PDF file
+- `--tsv` (optional) indicates that the toc file format is tab-delimited
+- `<page>` (optional) sets the default page to display when the PDF opens (defaults to 1)
+- `--fit` (optional) sets the default zoom for when the PDF opens, can be either `page` or `width`
+- `--print-pdfmarks` (optional) is for debugging purposes, prints `pdfmarks` and exists (doesn't create an output PDF)
 
 [1]: http://blog.tremily.us/posts/PDF_bookmarks_with_Ghostscript/
 [2]: http://ghostscript.com/

--- a/README.md
+++ b/README.md
@@ -35,14 +35,46 @@ otherwise it is closed. The exclamation mark indicates the end of those asterisk
 the beginning of the bookmark title. There are one or more spaces, i.e. ' ', after the title,
 then follows the page number. In summary, each line of toc
 file should match the regular expression `(^\**)(1?)!(.+?)\s+(-?[0-9]+)\s*$`.
+
+## Alternative Toc file format (Tab-delemited)
+If preferred, a tab-delimited format can be used instead as the toc file (by passing `--tsv` to the command line).
+It has a fixed number of columns and hence easier to edit in Excel or other tabular editors. The columns are:
+```
+Level,IsOpen,Title,Page
+```
+
+The tab-delimited equivalent of the above toc would be:
+
+|||||
+|-|-|-|-|
+|0||Contents|1|
+|0||0. Introduction|2|
+|0||1. First section|3|
+|1|*|1.1 Subsection|3|
+|2||1.1.1 Subsubsection|3|
+|2||1.1.2 Another subsubsection|5|
+|1||1.2 Another subsection|7|
+|0||2. Second section|8|
+|1||2.1 Subsection|3|
+|1||2.2 Subsection|3|
+|0||3. Third section|8|
+
+Where:
+- `Level` is a non-empty zero-based integer indicating the depth of the current item in the bookmarks
+- `IsOpen`, if not blank, indicates whether this entry is opened by default, and can be any **single character**
+- The file can't contain empty lines, headers, comments, etc.
+
+Technically, each line of this toc format should match the regular expression `^([0-9]+)\t(.?)\t(.+?)\t(-?[0-9]+)$`.
+
 # Usage
 ```
-$ pdfmark --in <input> --toc <toc-file> --out <output> [--offset <offset>]
+$ pdfmark --in <input> --toc <toc-file> --out <output> [--offset <offset>] [--tsv]
 ```
 Where `<input>`, and `<output>` are input PDF and output PDF, `<toc-file>`
 is the toc file as described above, and the option `<offset>` is optional, it
 stands for the offset that should be added to the page numbers in toc file in order
 to get the real page number in the PDF file.
+Use `--tsv` to indicate that the toc file format is tab-delimited.
 
 [1]: http://blog.tremily.us/posts/PDF_bookmarks_with_Ghostscript/
 [2]: http://ghostscript.com/

--- a/pdfmark.py
+++ b/pdfmark.py
@@ -17,6 +17,12 @@ def tounicode(s):
             s = s.replace(x, y)
         return '({})'.format(s)
 
+def unquote(s: str):
+    """ when tab-delimited files are edited in Excel, it adds artificial quotes around titles with commas """
+    if s.startswith('"') and s.endswith('"'):
+        return s[1:-1]
+    return s
+
 def parsetoc(s, legacy_format=True):
     '''Parse toc file.
 
@@ -56,7 +62,7 @@ def parsetoc(s, legacy_format=True):
             return (j, l)
         level = len(m.group(1)) if legacy_format else int(m.group(1))
         res.append({'count': 0, 'flag': '' if m.group(2) else '-',
-            'title': m.group(3), 'page': int(m.group(4))})
+            'title': unquote(m.group(3)), 'page': int(m.group(4))})
 
         if level > lastlevel + 1:
             return (j, l)


### PR DESCRIPTION
I find that the proposed toc format (based on `*` and `!`) is less friendly for humans as well as editors :-)
I believe a tab-delimited alternative can be useful for others as it was for me.

Also, having added bookmarks, one should expect them to be visible when the PDF opens.
So while adding this, I also allowed user to have some control over the default page and zoom to display when the PDF opens.